### PR TITLE
remove trim() from stripNonASCII

### DIFF
--- a/src/util/text-util.ts
+++ b/src/util/text-util.ts
@@ -17,7 +17,7 @@ const stripExtraSpace = (text: string): string => text.replace(/\s{2,}/gm, ' ').
  * @param {string} text
  * @returns {string}
  */
-const stripNonASCII = (text: string): string => text.replace(/[^\x00-\x7F]/g, '').trim();
+const stripNonASCII = (text: string): string => text.replace(/[^\x00-\x7F]/g, '');
 
 /**
  * Removes common punctuation characters from a string


### PR DESCRIPTION
Thanks for sharing this libraray.

I think that trim() is outside the scope of stripNonASCII and it surprised me using it to clean some data that needed to have whitespace at the end.  I've removed it in this PR if you are interested.


