### PR TITLE
Add CI size check for exported library bundles

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,0 +1,23 @@
+name: Size
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - uses: andresz1/size-limit-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          skip_step: install

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -16,8 +16,6 @@ jobs:
         with:
           node-version: 22
           cache: npm
-      - run: npm ci
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          skip_step: install

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,13 +1,13 @@
 [
   {
     "path": "dist/index.mjs",
-    "limit": "25 KB",
+    "limit": "10 KB",
     "gzip": true,
     "name": "ESM"
   },
   {
     "path": "dist/index.js",
-    "limit": "25 KB",
+    "limit": "10 KB",
     "gzip": true,
     "name": "CJS"
   }

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,14 @@
+[
+  {
+    "path": "dist/index.mjs",
+    "limit": "25 KB",
+    "gzip": true,
+    "name": "ESM"
+  },
+  {
+    "path": "dist/index.js",
+    "limit": "25 KB",
+    "gzip": true,
+    "name": "CJS"
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.4",
+        "@size-limit/file": "^12.0.0",
         "@types/node": "^25.3.2",
+        "size-limit": "^12.0.0",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
@@ -1013,6 +1015,19 @@
         "win32"
       ]
     },
+    "node_modules/@size-limit/file": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.0.0.tgz",
+      "integrity": "sha512-OzKYpDzWJ2jo6cAIzVsaPuvzZTmMLDoVCViEvsctmImxpXzwJZcuBEpPohFKKdgVdZuNTU8WstmvywPq55Njdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1210,6 +1225,16 @@
       },
       "peerDependencies": {
         "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/cac": {
@@ -1508,6 +1533,16 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1725,6 +1760,34 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/size-limit": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.0.0.tgz",
+      "integrity": "sha512-JBG8dioIs0m2kHOhs9jD6E/tZKD08vmbf2bfqj/rJyNWqJxk/ZcakixjhYtsqdbi+AKVbfPkt3g2RRZiKaizYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "jiti": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
     },
     "node_modules/source-map": {
       "version": "0.7.6",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "test:watch": "vitest",
     "lint": "biome check src/",
     "format": "biome format --write src/",
-    "size": "size-limit",
-    "size:why": "size-limit --why"
+    "size": "size-limit"
   },
   "keywords": [
     "text",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "biome check src/",
-    "format": "biome format --write src/"
+    "format": "biome format --write src/",
+    "size": "size-limit",
+    "size:why": "size-limit --why"
   },
   "keywords": [
     "text",
@@ -54,7 +56,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",
+    "@size-limit/file": "^12.0.0",
     "@types/node": "^25.3.2",
+    "size-limit": "^12.0.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"


### PR DESCRIPTION
## Summary

- **Add size-limit** with `@size-limit/file` plugin to track gzipped bundle sizes
- **Add GitHub Actions workflow** (`.github/workflows/size.yml`) that posts a size comparison comment on every PR to master via `andresz1/size-limit-action`
- **10 KB gzipped limit** for both ESM and CJS outputs (current sizes: 6.15 KB ESM, 6.87 KB CJS)
- **Warning only** — the size check posts a comment but does not block merging
- **Add `npm run size`** script for local size checking

## Test plan

- [x] `npm run size` reports correct gzipped sizes (6.15 KB ESM, 6.87 KB CJS)
- [x] `npm run build` still passes
- [x] `npm test` still passes (112 tests)
- [x] `npm run lint` still passes
- [ ] Verify the Size workflow runs on this PR and posts a comment

## Post-deploy monitoring

No operational impact — this is a CI-only change. The size workflow only runs on PRs and has no effect on the published package.

## Deferred (P3)

- Consider pinning `andresz1/size-limit-action` to a full commit SHA instead of `@v1` for supply chain hardening (informational recommendation from security review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)