### PR TITLE
ci: automate npm publishing

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1,0 +1,26 @@
+# Releasing
+
+Publishing is handled by `.github/workflows/publish.yml` when a GitHub release is published.
+
+## One-time npm setup
+
+In the npm settings for `clean-text-utils`, add a GitHub Actions trusted publisher with:
+
+- Organization or user: `daviseford`
+- Repository: `clean-text-utils`
+- Workflow filename: `publish.yml`
+- Environment: leave blank
+- Allowed action: `npm publish`
+
+No npm token is stored in GitHub. The workflow authenticates with OpenID Connect.
+
+## Publish a release
+
+1. Update the version in `package.json` and `package-lock.json`, then merge that change to `master`.
+2. Create a GitHub release whose tag exactly matches the package version:
+
+   ```sh
+   gh release create v1.3.0 --target master --generate-notes
+   ```
+
+The workflow rejects mismatched release tags and package versions before publishing.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1,6 +1,8 @@
 # Releasing
 
-Publishing is handled by `.github/workflows/publish.yml` when a GitHub release is published.
+Publishing is handled by `.github/workflows/publish.yml` whenever a commit lands on `master`.
+The workflow reads the version from `package.json`, skips versions that already exist on npm, and
+publishes new versions.
 
 ## One-time npm setup
 
@@ -16,11 +18,9 @@ No npm token is stored in GitHub. The workflow authenticates with OpenID Connect
 
 ## Publish a release
 
-1. Update the version in `package.json` and `package-lock.json`, then merge that change to `master`.
-2. Create a GitHub release whose tag exactly matches the package version:
+1. Update the version in `package.json` and `package-lock.json`.
+2. Merge that change to `master`.
 
-   ```sh
-   gh release create v1.3.0 --target master --generate-notes
-   ```
-
-The workflow rejects mismatched release tags and package versions before publishing.
+The push to `master` runs the package checks and publishes the new version automatically. Rerunning
+the workflow, or pushing another commit without changing the version, exits successfully without
+publishing again.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,16 @@
 name: Publish to npm
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: read
   id-token: write
 
 concurrency:
-  group: npm-publish-${{ github.event.release.tag_name }}
+  group: npm-publish
   cancel-in-progress: false
 
 jobs:
@@ -23,7 +24,28 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
       - run: npm ci
-      - name: Verify release tag matches package version
+      - name: Check whether this version is already published
+        id: version
+        shell: bash
         run: |
-          node -e "const { version } = require('./package.json'); const expected = `v${version}`; if (process.env.GITHUB_REF_NAME !== expected) { console.error(`Release tag ${process.env.GITHUB_REF_NAME} does not match package version ${expected}`); process.exit(1); }"
-      - run: npm publish
+          package_name=$(node -p "require('./package.json').name")
+          package_version=$(node -p "require('./package.json').version")
+          package_spec="${package_name}@${package_version}"
+
+          set +e
+          npm_output=$(npm view "$package_spec" version --json 2>&1)
+          npm_status=$?
+          set -e
+
+          if [ "$npm_status" -eq 0 ]; then
+            echo "$package_spec is already published; nothing to do."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          elif grep -q '"code": "E404"' <<< "$npm_output"; then
+            echo "$package_spec is not published yet."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "$npm_output" >&2
+            exit "$npm_status"
+          fi
+      - if: steps.version.outputs.should_publish == 'true'
+        run: npm publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - run: npm ci
+      - name: Verify release tag matches package version
+        run: |
+          node -e "const { version } = require('./package.json'); const expected = `v${version}`; if (process.env.GITHUB_REF_NAME !== expected) { console.error(`Release tag ${process.env.GITHUB_REF_NAME} does not match package version ${expected}`); process.exit(1); }"
+      - run: npm publish


### PR DESCRIPTION
## Summary

New `clean-text-utils` versions are now published to npm automatically when a commit lands on `master`. The job uses npm Trusted Publishing, skips versions that already exist on npm, and relies on the package's existing prepublish checks to validate the exact artifact.

One npm-side trusted-publisher binding is required before this PR is merged so the merge-triggered publish can authenticate.

## Validation

- `actionlint` 1.7.12 passed
- `npm run check` passed: 123 tests, lint, type checks, package smoke tests, export/type validation, bundle budgets, and zero audit vulnerabilities
- The version detector skipped published `1.2.1` and selected unpublished `1.3.0`
- The live OIDC handshake remains pending until the npm trusted publisher is configured and this workflow runs on `master`

## Post-Deploy Monitoring & Validation

- Watch the `Publish to npm` GitHub Actions run triggered by merging this PR and search its logs for `ENEEDAUTH`, `E403`, registry lookup errors, or package lifecycle failures.
- Healthy: the workflow completes once and `npm view clean-text-utils version` returns `1.3.0`.
- Failure: the workflow fails or npm does not expose `1.3.0` within 10 minutes.
- Mitigation: correct the trusted-publisher/workflow configuration and rerun the failed job. If an incorrect package is published, deprecate that version and publish a corrected patch.
- Validation window and owner: the merge-triggered publish plus 24 hours, owned by the package maintainer.

## New concepts

### OIDC trusted publishing

Trusted publishing lets GitHub prove a workflow's identity to npm using a short-lived OpenID Connect credential. No reusable publish token is stored in repository secrets.

Here, npm will trust only `daviseford/clean-text-utils` running `publish.yml`. This is preferable to an automation token because the credential is created for each publish run and cannot be reused later.

Use this pattern for CI-owned releases. It is unnecessary for packages that intentionally remain manual-only.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)